### PR TITLE
changed slugify library to cutlet.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+dist/
+build/
+*.egg-info/

--- a/redasher/mapper.py
+++ b/redasher/mapper.py
@@ -1,6 +1,7 @@
 from yamlns import namespace as ns
 from pathlib import Path
-from slugify import slugify
+import cutlet
+katsu = cutlet.Cutlet()
 
 class Mapper(object):
     """Keeps track of the binding of server objects
@@ -22,7 +23,7 @@ class Mapper(object):
 
     def _slugger(self, base):
         "Returns first the slug as is, then adding sequence numbers"
-        slug = slugify(base)
+        slug = katsu.slug(base)
         from itertools import count
         yield slug
         for c in count(2):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 click
 requests
 yamlns
-python-slugify
 consolemsg
 packaging
 decorator
 appdirs
+unidic-lite
+cutlet


### PR DESCRIPTION
Changed directory naming from slugify to cutlet.

This is because slugify is not appropreate for Japanese sentences. Slugify recognize Chinese characters as Chinese. 
Cutlet can recognize chinese character used in Japanese appropreately.